### PR TITLE
Pypad Glasscoder modification

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -867,3 +867,9 @@
 	* Fixed a bug in glasscoder(1) where the script specified in the
 	'--server-script-down' switch would fail to be executed during
 	shutdown.
+2020-01-23 Gabriele Fergola <workino@gmail.com>
+	* Corrected the exception on utf8 characters movin pypad_glasscoder.py
+	  from pycurl to requests.
+	* Rewrote the json loop in pypad_glasscoder.py
+	* Increased debug in pypad_glasscoder.py
+	* Added [PyPAD][Glasscoder] Tags to better recognize in syslog/messages

--- a/ChangeLog
+++ b/ChangeLog
@@ -846,8 +846,3 @@
 	* Incremented the package version to 0.10.0.
 2020-01-09 Fred Gleason <fredg@paravelsystems.com>
 	* Updated glasscoder(1) to work properly with FDK-AACv2.
-2020-01-23 Gabriele Fergola <workino@gmail.com>
-  * Corrected the exception on utf8 characters movin pypad_glasscoder.py
-	  from pycurl to requests.
-	* Rewrote the json loop in pypad_glasscoder.py
-  * Increased debug in pypad_glasscoder.py

--- a/ChangeLog
+++ b/ChangeLog
@@ -846,3 +846,8 @@
 	* Incremented the package version to 0.10.0.
 2020-01-09 Fred Gleason <fredg@paravelsystems.com>
 	* Updated glasscoder(1) to work properly with FDK-AACv2.
+2020-01-23 Gabriele Fergola <workino@gmail.com>
+  * Corrected the exception on utf8 characters movin pypad_glasscoder.py
+	  from pycurl to requests.
+	* Rewrote the json loop in pypad_glasscoder.py
+  * Increased debug in pypad_glasscoder.py

--- a/plugins/pypad_glasscoder.py
+++ b/plugins/pypad_glasscoder.py
@@ -23,7 +23,6 @@
 import sys
 import syslog
 import configparser
-import pycurl
 import pypad
 import json
 import requests

--- a/plugins/pypad_glasscoder.py
+++ b/plugins/pypad_glasscoder.py
@@ -39,7 +39,6 @@ def ProcessPad(update):
         section='Line'+str(n)
         while(update.config().has_section(section)):
             lines.append('"%s": "%s"' % (update.config().get(section,'Key'), update.resolvePadFields(update.config().get(section,'Value'),pypad.ESCAPE_JSON)))
-            # lines.append('"'+update.config().get(section,'Key')+'": "'+update.resolvePadFields(update.config().get(section,'Value'),pypad.ESCAPE_JSON)+'"')
             n=n+1
             section='Line'+str(n)
 
@@ -48,9 +47,9 @@ def ProcessPad(update):
             req_url = update_url+'/json_pad'
             try:
                 r = requests.post(req_url, json=json.loads(req_data))
-                update.syslog(syslog.LOG_INFO,'Update code: ' + str(r.status_code))
+                update.syslog(syslog.LOG_INFO,'[PyPAD][Glasscoder] Update exit code: ' + str(r.status_code))
             except requests.exceptions.RequestException as e:
-                update.syslog(syslog.LOG_WARNING,'Update failed: ' + e)
+                update.syslog(syslog.LOG_WARNING,'[PyPAD][Glasscoder] Update failed: ' + e)
 
 #
 # 'Main' function

--- a/plugins/pypad_glasscoder.py
+++ b/plugins/pypad_glasscoder.py
@@ -49,7 +49,7 @@ def ProcessPad(update):
                 r = requests.post(req_url, json=json.loads(req_data))
                 update.syslog(syslog.LOG_INFO,'[PyPAD][Glasscoder] Update exit code: ' + str(r.status_code))
             except requests.exceptions.RequestException as e:
-                update.syslog(syslog.LOG_WARNING,'[PyPAD][Glasscoder] Update failed: ' + e)
+                update.syslog(syslog.LOG_WARNING,'[PyPAD][Glasscoder] Update failed: ' + str(e))
 
 #
 # 'Main' function

--- a/plugins/pypad_glasscoder.py
+++ b/plugins/pypad_glasscoder.py
@@ -48,8 +48,9 @@ def ProcessPad(update):
             req_url = update_url+'/json_pad'
             try:
                 r = requests.post(req_url, json=json.loads(req_data))
+                update.syslog(syslog.LOG_INFO,'Update code: ' + str(r.status_code))
             except requests.exceptions.RequestException as e:
-                update.syslog(syslog.LOG_WARNING,'update failed: ' + e)
+                update.syslog(syslog.LOG_WARNING,'Update failed: ' + e)
 
 #
 # 'Main' function


### PR DESCRIPTION
Hello Fred i did some modification to the pypad glasscoder script. Now it will not stop to work if utf8 characters  found.

I also moved from pycurl to requests is more flexible with utf json.
I cleaned also the the json.
The problem now look like glasscoder still is sending strange characters to icecast server like:
Coez - La musica non c'Ã¨

The post is sent with correct data (utf-8) 

Regards
Gabriele 